### PR TITLE
Remove background shadow for safari

### DIFF
--- a/src/app/css/overrides.scss
+++ b/src/app/css/overrides.scss
@@ -167,4 +167,5 @@ p {
 .govuk-back-link {
   border: none;
   font-weight: bold;
+  background: transparent;
 }


### PR DESCRIPTION
<img width="877" alt="image" src="https://user-images.githubusercontent.com/54268893/76304272-00337480-62bb-11ea-8be9-82b40bc789a5.png">
