### PR TITLE
Activity search: style snags

### DIFF
--- a/cypress/integration/pages/details.spec.js
+++ b/cypress/integration/pages/details.spec.js
@@ -28,7 +28,7 @@ describe('Details Page', () => {
       it('can search by note title', () => {
         const testNoteTitle = 'Case Note';
 
-        cy.get('#search')
+        cy.get('#searchActivity')
           .scrollIntoView()
           .should('be.visible')
           .type(testNoteTitle, { force: true });
@@ -41,7 +41,7 @@ describe('Details Page', () => {
       it('can search by note text', () => {
         const testNoteText = 'Change in Circs ICL';
 
-        cy.get('#search')
+        cy.get('#searchActivity')
           .scrollIntoView()
           .should('be.visible')
           .type(testNoteText, { force: true });

--- a/src/app/Components/Details/ActivitySearch/index.jsx
+++ b/src/app/Components/Details/ActivitySearch/index.jsx
@@ -72,11 +72,11 @@ export default class ActivitySearch extends Component {
         <input
           type="text"
           placeholder="Search"
-          id="search"
+          id="searchActivity"
           className="govuk-input"
           value={this.state.searchTerm}
           onChange={this.handleSearchTermChange}
-          onFocus={e => this.setState({ filter: null })}
+          onFocus={e => this.setState({ filter: null, showFilters: true })}
         />
         <button onClick={this.toggleFilters}>{this.searchIcon()}</button>
         <div hidden={!this.state.filter}>

--- a/src/app/Components/Details/ActivitySearch/index.scss
+++ b/src/app/Components/Details/ActivitySearch/index.scss
@@ -27,7 +27,7 @@
 
   button {
     float: left;
-    padding: 9px;
+    padding: 8px;
     background: #00664f;
     color: white;
     border: 2px solid #0b0c0c;
@@ -36,6 +36,7 @@
     border-left: none;
     height: 34px;
     width: 34px;
+    font-size: 14px;
 
     :hover {
       background: #00513f
@@ -49,6 +50,11 @@
   top: 32px;
   padding: 6px;
   background: #fff;
+
+  a {
+    display: block;
+    margin: 6px 0;
+  }
 }
 
 


### PR DESCRIPTION
<img width="182" alt="Screenshot 2020-03-10 at 16 11 37" src="https://user-images.githubusercontent.com/8051117/76333894-320fff80-62ea-11ea-91ab-b7738dea644e.png">

- Seach/X icon made bigger
- More padding around filters
- Open filters when search is focused 