### PR TITLE
Display jigsaw docs

### DIFF
--- a/src/app/Components/Details/AddressDetails/index.jsx
+++ b/src/app/Components/Details/AddressDetails/index.jsx
@@ -31,15 +31,15 @@ export default class AddressDetails extends Component {
                       <p key={i} title={address.source.join(', ')}>
                         <p>{this.lineBreakifyAddress(address.address)}</p>
                         <details
-                          class="govuk-details"
+                          className="govuk-details"
                           data-module="govuk-details"
                         >
-                          <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">
+                          <summary className="govuk-details__summary">
+                            <span className="govuk-details__summary-text">
                               Where is this from?
                             </span>
                           </summary>
-                          <div class="govuk-details__text">
+                          <div className="govuk-details__text">
                             {this.lineBreakifyAddress(address.source)}
                           </div>
                         </details>

--- a/src/app/Components/Details/Note/index.jsx
+++ b/src/app/Components/Details/Note/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import moment from 'moment';
 import DocumentModal from '../../DocumentModal';
+import { FetchJigsawDoc } from '../../../Gateways';
 
 export default class Note extends Component {
   state = {
@@ -34,9 +35,16 @@ export default class Note extends Component {
         this.props.note.format === '.pdf'
       ) {
         this.setState({
-          docUrl: `${process.env.REACT_APP_JIGSAW_DOCUMENT_API_URL}/customers/${this.props.note.userid}/documents/jigsaw/${this.props.note.id}`,
           showDoc: true
         });
+        FetchJigsawDoc(this.props.note.userid, this.props.note.id)
+          .then(response => response.blob())
+          .then(blob => {
+            const tempUrl = URL.createObjectURL(blob);
+            this.setState({
+              docUrl: tempUrl
+            });
+          });
       }
     }
   };
@@ -100,7 +108,7 @@ export default class Note extends Component {
       noteComponent = (
         <strong>
           <p>
-            <a onClick={this.click} href="#/" class="govuk-link">
+            <a onClick={this.click} href="#/" className="govuk-link">
               {note.title}
             </a>
           </p>

--- a/src/app/Gateways/FetchJigsawDoc.js
+++ b/src/app/Gateways/FetchJigsawDoc.js
@@ -1,0 +1,12 @@
+import { AuthHeader } from '.';
+
+function FetchJigsawDoc(userId, documentId) {
+  return fetch(
+    `${process.env.REACT_APP_JIGSAW_DOCUMENT_API_URL}/customers/${userId}/documents/jigsaw/${documentId}`,
+    AuthHeader
+  ).then(function(response) {
+    return response;
+  });
+}
+
+export default FetchJigsawDoc;

--- a/src/app/Gateways/index.js
+++ b/src/app/Gateways/index.js
@@ -5,6 +5,7 @@ import FetchCustomerDocuments from './FetchCustomerDocuments';
 import SearchCustomers from './SearchCustomers';
 import DeleteCustomerRecord from './DeleteCustomerRecord';
 import AddVulnerability from './AddVulnerability';
+import FetchJigsawDoc from './FetchJigsawDoc';
 import { hackneyToken } from '../lib/Cookie';
 
 const AuthHeader = {
@@ -22,5 +23,6 @@ export {
   FetchCustomerDocuments,
   SearchCustomers,
   DeleteCustomerRecord,
-  AddVulnerability
+  AddVulnerability,
+  FetchJigsawDoc
 };

--- a/src/app/Pages/DetailsPage/index.jsx
+++ b/src/app/Pages/DetailsPage/index.jsx
@@ -68,7 +68,7 @@ export default class DetailsPage extends Component {
       <div>
         <div className="lbh-container row details">
           <p>
-            <button onClick={this.goBack} class="govuk-back-link">
+            <button onClick={this.goBack} className="govuk-back-link">
               Back to search
             </button>
           </p>

--- a/src/app/Pages/VulnerabilitiesPage/index.jsx
+++ b/src/app/Pages/VulnerabilitiesPage/index.jsx
@@ -55,103 +55,103 @@ export default class VulnerabilitiesPage extends Component {
           <h3 className="lbh-heading-h3">What to look out for</h3>
         </div>
         <div
-          class="govuk-accordion lbh-accordion"
+          className="govuk-accordion lbh-accordion"
           data-module="govuk-accordion"
         >
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h5 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button">
+          <div className="govuk-accordion__section ">
+            <div className="govuk-accordion__section-header">
+              <h5 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button">
                   Active case with other services?
                 </span>
               </h5>
             </div>
-            <div class="govuk-accordion__section-content">
-              <ul class="lbh-list lbh-list--bullet">
+            <div className="govuk-accordion__section-content">
+              <ul className="lbh-list lbh-list--bullet">
                 <li>Example item 1</li>
               </ul>
             </div>
           </div>
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h5 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button">
+          <div className="govuk-accordion__section ">
+            <div className="govuk-accordion__section-header">
+              <h5 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button">
                   At risk of arrears?
                 </span>
               </h5>
             </div>
-            <div class="govuk-accordion__section-content">
-              <ul class="lbh-list lbh-list--bullet">
+            <div className="govuk-accordion__section-content">
+              <ul className="lbh-list lbh-list--bullet">
                 <li>Example item 2</li>
               </ul>
             </div>
           </div>
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h5 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button">
+          <div className="govuk-accordion__section ">
+            <div className="govuk-accordion__section-header">
+              <h5 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button">
                   Benefits trigger events?
                 </span>
               </h5>
             </div>
-            <div class="govuk-accordion__section-content">
-              <ul class="lbh-list lbh-list--bullet">
+            <div className="govuk-accordion__section-content">
+              <ul className="lbh-list lbh-list--bullet">
                 <li>Example item 2</li>
               </ul>
             </div>
           </div>
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h5 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button">
+          <div className="govuk-accordion__section ">
+            <div className="govuk-accordion__section-header">
+              <h5 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button">
                   Unusual behaviour?
                 </span>
               </h5>
             </div>
-            <div class="govuk-accordion__section-content">
-              <ul class="lbh-list lbh-list--bullet">
+            <div className="govuk-accordion__section-content">
+              <ul className="lbh-list lbh-list--bullet">
                 <li>Example item 2</li>
               </ul>
             </div>
           </div>
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h5 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button">
+          <div className="govuk-accordion__section ">
+            <div className="govuk-accordion__section-header">
+              <h5 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button">
                   Significant change or transition?
                 </span>
               </h5>
             </div>
-            <div class="govuk-accordion__section-content">
-              <ul class="lbh-list lbh-list--bullet">
+            <div className="govuk-accordion__section-content">
+              <ul className="lbh-list lbh-list--bullet">
                 <li>Example item 2</li>
               </ul>
             </div>
           </div>
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h5 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button">
+          <div className="govuk-accordion__section ">
+            <div className="govuk-accordion__section-header">
+              <h5 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button">
                   Emotional shock?
                 </span>
               </h5>
             </div>
-            <div class="govuk-accordion__section-content">
-              <ul class="lbh-list lbh-list--bullet">
+            <div className="govuk-accordion__section-content">
+              <ul className="lbh-list lbh-list--bullet">
                 <li>Example item 2</li>
               </ul>
             </div>
           </div>
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h5 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button">
+          <div className="govuk-accordion__section ">
+            <div className="govuk-accordion__section-header">
+              <h5 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button">
                   Level of stress?
                 </span>
               </h5>
             </div>
-            <div class="govuk-accordion__section-content">
-              <ul class="lbh-list lbh-list--bullet">
+            <div className="govuk-accordion__section-content">
+              <ul className="lbh-list lbh-list--bullet">
                 <li>Example item 2</li>
               </ul>
             </div>


### PR DESCRIPTION
Previously we were trying to retrieve the jigsaw doc by calling the fetch jigsaw doc api directly, this worked fine in development however on server we need to send the authentication token. 
In this refactor I've introduced a new gateway that will make an authenticated fetch to grab the doc from the api, then make a temp url for that document and send it to the iframe for the document to be displayed 